### PR TITLE
allow dart 2 SDK in pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,8 @@
 name: assortment
-version: 0.1.4
+version: 0.1.4+1
 author: Christopher Best <bestchris@gmail.com>
 description: Simple sortable DOM elements in Dart using HTML5 drag and drop
 homepage: https://github.com/sirctseb/assortment
 documentation: http://sirctseb.github.io/assortment
 environment:
-  sdk: '>=0.8.10+6 <2.0.0'
+  sdk: '>=0.8.10+6 <3.0.0'


### PR DESCRIPTION
warning: I haven't fully tested this yet. For now,I naively updated the constraint and didn't see any analyzer warnings.